### PR TITLE
Start with fresh bin dir on makefile

### DIFF
--- a/main/ToS_Fourm_Mafia_Note_Taker/makefile
+++ b/main/ToS_Fourm_Mafia_Note_Taker/makefile
@@ -1,4 +1,6 @@
 build:
+	rm -R bin
+	mkdir -p bin
 	javac -d bin -sourcepath src src/main/Main.java
 run:
 	java -cp bin main.Main


### PR DESCRIPTION
Start with a fresh "bin" directory when building from source.

Nothing worth a hotfix, just something that needs to be put in for those of us who use the terminal instead of an IDE.
